### PR TITLE
Update ci.yml - build CompetitionSoftware project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,5 @@ jobs:
         uses: actions/checkout@v3
       - name: Gradle Build
         run: |
-          chmod +x ./BasicDrive/gradlew
-          cd BasicDrive && ./gradlew build
+          chmod +x ./CompetitionSoftware/gradlew
+          cd CompetitionSoftware && ./gradlew build


### PR DESCRIPTION
Previous version built a project called BasicDrive from the root directory of the repo but we've reorganized and now need to build CompetitionSoftware instead.